### PR TITLE
fix: ignore bt runtime artifacts in gitignore (#45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ yarn-debug.log*
 yarn-error.log*
 .DS_Store
 
+# Biotonomy runtime artifacts (created when running bt inside this repo)
+.bt/
+.bt.env
+specs/issue-*/
+specs/feat-*/
+


### PR DESCRIPTION
Fixes #45. Adds .bt/, .bt.env, specs/issue-*/, specs/feat-*/ to .gitignore so running biotonomy inside its own repo doesn't pollute git status or break subsequent test/loop runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to exclude runtime artifacts and specification directories from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->