### PR TITLE
fix(loop): harden convergence rubric and isolate gate env leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ bt loop "$FEATURE" --max-iterations 3
 
 Loop hard-requires an approved `specs/<feature>/PLAN_REVIEW.md` verdict (`APPROVE_PLAN` or `APPROVED_PLAN`).
 
+Optional strict mode:
+- `BT_LOOP_STRICT_REVIEW_DELTA=1` fails the loop when a new `REVIEW.md` finding appears without `[REGRESSION]` or `[SPEC_GAP]` tagging (or clear fixed-rubric/SPEC tie-in).
+
 ## Artifacts And State
 
 Biotonomy writes feature state under `specs/<feature>/`:

--- a/lib/gates.sh
+++ b/lib/gates.sh
@@ -103,6 +103,15 @@ bt__gate_script_exists() {
   return 0  # Can't verify, assume exists
 }
 
+bt__gate_run_cmd() {
+  local cmd="$1"
+  (
+    cd "$BT_PROJECT_ROOT" || exit 1
+    # Keep user env, but avoid leaking bt root/target plumbing into child test processes.
+    env -u BT_PROJECT_ROOT -u BT_ENV_FILE -u BT_TARGET_DIR bash -lc "$cmd"
+  )
+}
+
 bt_run_gates() {
   local require_any=0
   if [[ "${1:-}" == "--require-any" ]]; then
@@ -149,7 +158,7 @@ bt_run_gates() {
 
     bt_info "gate: $k ($v)"
     local status=0
-    if ! (cd "$BT_PROJECT_ROOT" && bash -lc "$v"); then
+    if ! bt__gate_run_cmd "$v"; then
       bt_err "gate failed: $k"
       status=1
       overall_ok=1

--- a/prompts/plan-review.md
+++ b/prompts/plan-review.md
@@ -3,4 +3,15 @@
 Review the generated SPEC.md and RESEARCH.md (if exists) for the feature.
 Ensure the plan is sound and safe.
 
+Apply this fixed rubric:
+1. Security baseline
+2. Concurrency/idempotency
+3. Data retention/privacy
+4. Error contract determinism
+5. Required failure/race test coverage
+
+Rules:
+- Keep criteria fixed to SPEC + rubric above; do not move goalposts.
+- Any newly introduced finding must be tagged `[REGRESSION]` or `[SPEC_GAP]` (or explicitly tied to fixed rubric/SPEC evidence).
+
 Output Verdict: APPROVED_PLAN or Verdict: NEEDS_CHANGES.

--- a/prompts/review.md
+++ b/prompts/review.md
@@ -2,14 +2,19 @@
 
 You are the reviewer agent. You must not implement features; only identify issues.
 
-Checklist:
-- Correctness and edge cases
-- Tests: coverage and brittleness
-- Security and safety
-- Style and maintainability
+Use this fixed rubric for every review:
+1. Security baseline
+2. Concurrency/idempotency
+3. Data retention/privacy
+4. Error contract determinism
+5. Required failure/race test coverage
+
+Rules:
+- Do not introduce new criteria outside SPEC + fixed rubric.
+- New findings relative to the previous review must be tagged as `[REGRESSION]` or `[SPEC_GAP]` (or be explicitly tied to fixed rubric/SPEC evidence in the finding text).
+- No moving-goalposts: unchanged code should not get new untagged findings.
 
 Output:
 - Write `specs/<feature>/REVIEW.md` with:
   - `Verdict: APPROVE` or `Verdict: NEEDS_CHANGES`
   - A numbered list of findings with file paths and suggested fixes
-


### PR DESCRIPTION
## Summary
- isolate gate subprocess env from BT_PROJECT_ROOT/BT_ENV_FILE/BT_TARGET_DIR leakage
- add fixed review rubric anchors to plan-review/review prompts
- add strict review-delta mode () to fail on untagged new findings
- add tests for env leak regression, rubric anchors, and strict delta pass/fail behavior
- document strict mode in README

## Validation
- npm test
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional strict review delta mode validates that new review findings are properly tagged as [REGRESSION] or [SPEC_GAP].
  * Fixed review rubric now enforces criteria covering security baseline, concurrency/idempotency, data retention/privacy, error determinism, and test coverage.

* **Documentation**
  * README updated with strict mode configuration details.

* **Tests**
  * Added validation tests for environment isolation and strict review delta enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->